### PR TITLE
Increase width of the odometer wrapper

### DIFF
--- a/css/stars.css
+++ b/css/stars.css
@@ -162,7 +162,7 @@ body {
 
 .odometer-wrap-outermost {
   position: absolute;
-  width: 8em;
+  width: 10em;
   height: 100%;
   top: 0;
   right: 0;


### PR DESCRIPTION
It allows displaying 10K and 100K stars without truncation (see HubSpot/youmightnotneedjquery#189)